### PR TITLE
Add debug/release configs without JUCE submodule

### DIFF
--- a/OrkideMIDI/Builds/VisualStudio2022/OrkideMIDI.sln
+++ b/OrkideMIDI/Builds/VisualStudio2022/OrkideMIDI.sln
@@ -6,8 +6,14 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "OrkideMIDI - App", "OrkideM
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F05520AE-F116-3E0F-A012-4C029487B898}.Debug|x64.ActiveCfg = Debug|x64
+		{F05520AE-F116-3E0F-A012-4C029487B898}.Debug|x64.Build.0 = Debug|x64
+		{F05520AE-F116-3E0F-A012-4C029487B898}.Release|x64.ActiveCfg = Release|x64
+		{F05520AE-F116-3E0F-A012-4C029487B898}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OrkideMIDI/Builds/VisualStudio2022/OrkideMIDI_App.vcxproj
+++ b/OrkideMIDI/Builds/VisualStudio2022/OrkideMIDI_App.vcxproj
@@ -3,11 +3,36 @@
 <Project DefaultTargets="Build"
          ToolsVersion="17.0"
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Label="ProjectConfigurations"/>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{F05520AE-F116-3E0F-A012-4C029487B898}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props"/>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'"
+                 Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v143</PlatformToolset>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'"
+                 Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v143</PlatformToolset>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props"/>
   <ImportGroup Label="ExtensionSettings"/>
   <ImportGroup Label="PropertySheets">
@@ -18,7 +43,103 @@
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
     <TargetExt>.exe</TargetExt>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)$(Platform)\$(Configuration)\App\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(Platform)\$(Configuration)\App\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">OrkideMIDI</TargetName>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</GenerateManifest>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)$(Platform)\$(Configuration)\App\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(Platform)\$(Configuration)\App\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">OrkideMIDI</TargetName>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</GenerateManifest>
   </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Midl>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>true</MkTypLibCompatible>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TargetEnvironment>Win32</TargetEnvironment>
+      <HeaderFileName/>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>..\..\JuceLibraryCode;..\..\..\JUCE\modules;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;DEBUG;_DEBUG;JUCER_VS2022_78A503E=1;JUCE_APP_VERSION=1.0.0;JUCE_APP_VERSION_HEX=0x10000;JucePlugin_Build_VST=0;JucePlugin_Build_VST3=0;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=0;JucePlugin_Build_Unity=0;JucePlugin_Build_LV2=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <AssemblerListingLocation>$(IntDir)\</AssemblerListingLocation>
+      <ObjectFileName>$(IntDir)\</ObjectFileName>
+      <ProgramDataBaseFileName>$(IntDir)\OrkideMIDI.pdb</ProgramDataBaseFileName>
+      <WarningLevel>Level4</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>..\..\JuceLibraryCode;..\..\..\JUCE\modules;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;DEBUG;_DEBUG;JUCER_VS2022_78A503E=1;JUCE_APP_VERSION=1.0.0;JUCE_APP_VERSION_HEX=0x10000;JucePlugin_Build_VST=0;JucePlugin_Build_VST3=0;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=0;JucePlugin_Build_Unity=0;JucePlugin_Build_LV2=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <Link>
+      <OutputFile>$(OutDir)\OrkideMIDI.exe</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <IgnoreSpecificDefaultLibraries>libcmt.lib; msvcrt.lib;;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>$(IntDir)\OrkideMIDI.pdb</ProgramDatabaseFile>
+      <SubSystem>Windows</SubSystem>
+      <LargeAddressAware>true</LargeAddressAware>
+    </Link>
+    <Bscmake>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <OutputFile>$(IntDir)\OrkideMIDI.bsc</OutputFile>
+    </Bscmake>
+    <Lib/>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Midl>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>true</MkTypLibCompatible>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TargetEnvironment>Win32</TargetEnvironment>
+      <HeaderFileName/>
+    </Midl>
+    <ClCompile>
+      <Optimization>Full</Optimization>
+      <AdditionalIncludeDirectories>..\..\JuceLibraryCode;..\..\..\JUCE\modules;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;NDEBUG;JUCER_VS2022_78A503E=1;JUCE_APP_VERSION=1.0.0;JUCE_APP_VERSION_HEX=0x10000;JucePlugin_Build_VST=0;JucePlugin_Build_VST3=0;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=0;JucePlugin_Build_Unity=0;JucePlugin_Build_LV2=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <AssemblerListingLocation>$(IntDir)\</AssemblerListingLocation>
+      <ObjectFileName>$(IntDir)\</ObjectFileName>
+      <ProgramDataBaseFileName>$(IntDir)\OrkideMIDI.pdb</ProgramDataBaseFileName>
+      <WarningLevel>Level4</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>..\..\JuceLibraryCode;..\..\..\JUCE\modules;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;NDEBUG;JUCER_VS2022_78A503E=1;JUCE_APP_VERSION=1.0.0;JUCE_APP_VERSION_HEX=0x10000;JucePlugin_Build_VST=0;JucePlugin_Build_VST3=0;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=0;JucePlugin_Build_Unity=0;JucePlugin_Build_LV2=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <Link>
+      <OutputFile>$(OutDir)\OrkideMIDI.exe</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <ProgramDatabaseFile>$(IntDir)\OrkideMIDI.pdb</ProgramDatabaseFile>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <LargeAddressAware>true</LargeAddressAware>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+    <Bscmake>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <OutputFile>$(IntDir)\OrkideMIDI.bsc</OutputFile>
+    </Bscmake>
+    <Lib/>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Source\Main.cpp"/>
     <ClCompile Include="..\..\Source\MainComponent.cpp"/>
@@ -134,9 +255,6 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_audio_basics\utilities\juce_ADSR_test.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_basics\utilities\juce_AudioWorkgroup.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_audio_basics\utilities\juce_IIRFilter.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -167,9 +285,6 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\audio_io\juce_SampleRateHelpers.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\midi_io\juce_MidiDeviceListConnectionBroadcaster.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\midi_io\juce_MidiDevices.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -180,9 +295,6 @@
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\aaudio\AudioStreamAAudio.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\common\AdpfWrapper.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\common\AudioSourceCaller.cpp">
@@ -210,9 +322,6 @@
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\common\LatencyTuner.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\common\OboeExtensions.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\common\QuirksManager.cpp">
@@ -287,19 +396,10 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\FlowGraphNode.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\Limiter.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\ManyToMultiConverter.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\MonoBlend.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\MonoToMultiConverter.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\MultiToManyConverter.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\MultiToMonoConverter.cpp">
@@ -314,9 +414,6 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkFloat.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI8_24.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI16.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -327,9 +424,6 @@
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceFloat.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI8_24.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI16.cpp">
@@ -362,46 +456,46 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\opensles\OutputMixerOpenSLES.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_ALSA_linux.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_android_Audio.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_ASIO_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_android_Midi.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_Audio_android.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_android_Oboe.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_Audio_ios.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_android_OpenSL.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_Bela_linux.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_ios_Audio.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_CoreAudio_mac.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_linux_ALSA.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_DirectSound_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_linux_Bela.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_JackAudio.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_linux_JackAudio.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_Midi_android.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_linux_Midi.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_Midi_linux.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_mac_CoreAudio.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_Midi_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_win32_ASIO.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_Oboe_android.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_win32_DirectSound.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_OpenSL_android.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_win32_Midi.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_WASAPI_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_win32_WASAPI.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_audio_devices\sources\juce_AudioSourcePlayer.cpp">
@@ -422,16 +516,10 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_core\containers\juce_DynamicObject.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\containers\juce_Enumerate_test.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\containers\juce_FixedSizeFunction_test.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_core\containers\juce_HashMap_test.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\containers\juce_ListenerList_test.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\containers\juce_ListenerList.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_core\containers\juce_NamedValueSet.cpp">
@@ -485,13 +573,10 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_core\files\juce_WildcardFileFilter.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\json\juce_JSON.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\javascript\juce_Javascript.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\json\juce_JSONSerialisation_test.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\json\juce_JSONUtils.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\javascript\juce_JSON.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_core\logging\juce_FileLogger.cpp">
@@ -506,9 +591,6 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_core\maths\juce_Expression.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\maths\juce_MathsFunctions_test.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_core\maths\juce_Random.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -518,13 +600,7 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_core\memory\juce_MemoryBlock.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\memory\juce_SharedResourcePointer_test.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_core\misc\juce_ConsoleApplication.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\misc\juce_EnumHelpers_test.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_core\misc\juce_Result.cpp">
@@ -533,79 +609,70 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_core\misc\juce_RuntimePermissions.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\misc\juce_ScopeGuard.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_core\misc\juce_Uuid.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_AndroidDocument_android.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_android_AndroidDocument.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_CommonFile_linux.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_android_Files.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_Files_android.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_android_JNIHelpers.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_Files_linux.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_android_Misc.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_Files_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_android_Network.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_JNIHelpers_android.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_android_RuntimePermissions.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_Misc_android.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_android_SystemStats.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_NamedPipe_posix.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_android_Threads.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_Network_android.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_curl_Network.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_Network_curl.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_linux_CommonFile.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_Network_linux.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_linux_Files.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_Network_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_linux_Network.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_PlatformTimer_generic.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_linux_SystemStats.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_PlatformTimer_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_linux_Threads.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_Registry_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_posix_NamedPipe.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_RuntimePermissions_android.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_wasm_SystemStats.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_SystemStats_android.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_win32_Files.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_SystemStats_linux.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_win32_Network.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_SystemStats_wasm.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_win32_Registry.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_SystemStats_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_win32_SystemStats.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_Threads_android.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_Threads_linux.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_Threads_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_core\native\juce_win32_Threads.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_core\network\juce_IPAddress.cpp">
@@ -657,15 +724,6 @@
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_core\text\juce_CharacterFunctions.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\text\juce_CharPointer_UTF8_test.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\text\juce_CharPointer_UTF16_test.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\text\juce_CharPointer_UTF32_test.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_core\text\juce_Identifier.cpp">
@@ -728,39 +786,6 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_core\xml\juce_XmlElement.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\zip\zlib\adler32.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\zip\zlib\compress.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\zip\zlib\crc32.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\zip\zlib\deflate.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\zip\zlib\infback.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\zip\zlib\inffast.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\zip\zlib\inflate.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\zip\zlib\inftrees.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\zip\zlib\trees.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\zip\zlib\uncompr.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\zip\zlib\zutil.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_core\zip\juce_GZIPCompressorOutputStream.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -771,9 +796,6 @@
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_core\juce_core.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_core\juce_core_CompilationTime.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_data_structures\app_properties\juce_ApplicationProperties.cpp">
@@ -815,12 +837,6 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_events\broadcasters\juce_ChangeBroadcaster.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_events\broadcasters\juce_LockingAsyncUpdater.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_events\interprocess\juce_ChildProcessManager.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_events\interprocess\juce_ConnectedChildProcess.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -845,19 +861,19 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_events\messages\juce_MessageManager.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_events\native\juce_Messaging_android.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_events\native\juce_android_Messaging.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_events\native\juce_Messaging_linux.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_events\native\juce_Messaging_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_events\native\juce_linux_Messaging.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_events\native\juce_ScopedLowPowerModeDisabler.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_events\native\juce_WinRTWrapper_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_events\native\juce_win32_Messaging.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\..\JUCE\modules\juce_events\native\juce_win32_WinRTWrapper.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_events\timers\juce_MultiTimer.cpp">
@@ -884,19 +900,10 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\contexts\juce_GraphicsContext.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\contexts\juce_LowLevelGraphicsPostScriptRenderer.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\contexts\juce_LowLevelGraphicsSoftwareRenderer.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\detail\juce_JustifiedText.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\detail\juce_Ranges.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\detail\juce_ShapedText.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\detail\juce_SimpleShapedText.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\effects\juce_DropShadowEffect.cpp">
@@ -905,253 +912,16 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\effects\juce_GlowEffect.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Var\VARC\VARC.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\failing-alloc.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\harfbuzz-subset.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\harfbuzz.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-aat-layout.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-aat-map.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-blob.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-buffer-serialize.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-buffer-verify.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-buffer.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-common.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-coretext-font.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-coretext-shape.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-directwrite.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-draw.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-face-builder.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-face.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-fallback-shape.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-font.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ft.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-gdi.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-glib.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-gobject-structs.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-graphite2.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-icu.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-map.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-number.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-cff1-table.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-cff2-table.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-color.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-face.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-font.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-layout.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-map.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-math.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-meta.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-metrics.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-name.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shape-fallback.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shape-normalize.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shape.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-arabic.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-default.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-hangul.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-hebrew.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-indic-table.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-indic.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-khmer.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-myanmar.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-syllabic.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-thai.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-use.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-vowel-constraints.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-tag.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-var.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-outline.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-paint-extents.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-paint.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-set.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-shape-plan.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-shape.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-shaper.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-static.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-style.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-subset-cff-common.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-subset-cff1.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-subset-cff2.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-subset-input.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-subset-instancer-iup.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-subset-instancer-solver.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-subset-plan.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-subset-repacker.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-subset.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ucd.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-unicode.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-uniscribe.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-wasm-api.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-wasm-shape.cc">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\juce_AttributedString.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\juce_CustomTypeface.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\juce_Font.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\juce_FontOptions.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\juce_GlyphArrangement.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\juce_GlyphArrangementOptions.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\juce_TextLayout.cpp">
@@ -1160,16 +930,10 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\juce_Typeface.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\fonts\juce_TypefaceTestData.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\geometry\juce_AffineTransform.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\geometry\juce_EdgeTable.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\geometry\juce_Parallelogram_test.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\geometry\juce_Path.cpp">
@@ -1182,189 +946,6 @@
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\geometry\juce_Rectangle_test.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jcapimin.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jcapistd.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jccoefct.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jccolor.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jcdctmgr.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jchuff.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jcinit.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jcmainct.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jcmarker.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jcmaster.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jcomapi.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jcparam.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jcphuff.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jcprepct.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jcsample.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jctrans.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jdapimin.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jdapistd.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jdatasrc.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jdcoefct.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jdcolor.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jddctmgr.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jdhuff.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jdinput.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jdmainct.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jdmarker.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jdmaster.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jdmerge.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jdphuff.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jdpostct.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jdsample.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jdtrans.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jerror.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jfdctflt.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jfdctfst.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jfdctint.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jidctflt.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jidctfst.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jidctint.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jidctred.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jmemmgr.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jmemnobs.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jquant1.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jquant2.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jutils.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\transupp.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\png.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\pngerror.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\pngget.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\pngmem.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\pngpread.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\pngread.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\pngrio.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\pngrtran.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\pngrutil.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\pngset.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\pngtrans.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\pngwio.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\pngwrite.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\pngwtran.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\pngwutil.c">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\image_formats\juce_GIFLoader.cpp">
@@ -1388,139 +969,46 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\images\juce_ImageFileFormat.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_Direct2DGraphicsContext_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_android_Fonts.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_Direct2DGraphicsContextImpl_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_android_GraphicsContext.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_Direct2DImage_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_android_IconHelpers.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_Direct2DImageContext_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_freetype_Fonts.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_Direct2DMetrics_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_linux_Fonts.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_DirectWriteTypeface_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_linux_IconHelpers.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_DirectX_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_mac_IconHelpers.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_Fonts_android.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_win32_Direct2DGraphicsContext.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_Fonts_freetype.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_win32_DirectWriteTypeface.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_Fonts_linux.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_win32_DirectWriteTypeLayout.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_GraphicsContext_android.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_win32_Fonts.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_IconHelpers_android.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_IconHelpers_linux.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_IconHelpers_mac.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_IconHelpers_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\native\juce_win32_IconHelpers.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\placement\juce_RectanglePlacement.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\BidiChain.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\BidiTypeLookup.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\BracketQueue.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\GeneralCategoryLookup.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\IsolatingRun.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\LevelRun.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\PairingLookup.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\RunQueue.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\SBAlgorithm.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\SBBase.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\SBCodepointSequence.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\SBLine.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\SBLog.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\SBMirrorLocator.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\SBParagraph.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\SBScriptLocator.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\ScriptLookup.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\ScriptStack.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\SheenBidi.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\StatusStack.c">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\juce_Unicode.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\juce_UnicodeBidi.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\juce_UnicodeGenerated.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\juce_UnicodeLine.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\juce_UnicodeScript.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\unicode\juce_UnicodeUtils.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\juce_graphics.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\juce_graphics_Harfbuzz.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_graphics\juce_graphics_Sheenbidi.c">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\accessibility\juce_AccessibilityHandler.cpp">
@@ -1584,12 +1072,6 @@
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\desktop\juce_Displays.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_AccessibilityHelpers.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_ComponentPeerHelpers.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\drawables\juce_Drawable.cpp">
@@ -1662,9 +1144,6 @@
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\keyboard\juce_ModifierKeys.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\layout\juce_BorderedComponentBoundsConstrainer.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\layout\juce_ComponentAnimator.cpp">
@@ -1766,6 +1245,9 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\misc\juce_FocusOutline.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\misc\juce_JUCESplashScreen.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\mouse\juce_ComponentDragger.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -1787,85 +1269,52 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\mouse\juce_MouseListener.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_Accessibility.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_Accessibility_android.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_Accessibility_windows.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_AccessibilityElement_windows.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_AccessibilityTextHelpers_test.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_ContentSharer_android.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_android_Accessibility.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_ContentSharer_ios.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_win32_Accessibility.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_Direct2DHwndContext_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_win32_AccessibilityElement.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_DragAndDrop_linux.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\x11\juce_linux_X11_DragAndDrop.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_DragAndDrop_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\x11\juce_linux_X11_Symbols.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_FileChooser_android.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\x11\juce_linux_XWindowSystem.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_FileChooser_linux.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_android_ContentSharer.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_FileChooser_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_android_FileChooser.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_NativeMessageBox_android.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_android_Windowing.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_NativeMessageBox_linux.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_ios_ContentSharer.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_NativeMessageBox_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_linux_FileChooser.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_ScopedDPIAwarenessDisabler.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_linux_Windowing.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_VBlank_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_win32_DragAndDrop.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_Windowing_android.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_win32_FileChooser.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_Windowing_linux.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_Windowing_windows.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_WindowsHooks_windows.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_WindowUtils_android.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_WindowUtils_linux.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_WindowUtils_windows.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_XSymbols_linux.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_XWindowSystem_linux.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_win32_Windowing.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\positioning\juce_MarkerList.cpp">
@@ -1940,9 +1389,6 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\widgets\juce_TextEditor.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\widgets\juce_TextEditorModel.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\widgets\juce_Toolbar.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -1970,19 +1416,7 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_DocumentWindow.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_MessageBoxOptions.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_NativeMessageBox.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_NativeScaleFactorNotifier.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_ResizableWindow.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_ScopedMessageBox.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_ThreadWithProgressWindow.cpp">
@@ -1994,7 +1428,7 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_TopLevelWindow.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_VBlankAttachment.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_VBlankAttachement.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_gui_basics\juce_gui_basics.cpp">
@@ -2051,46 +1485,43 @@
     <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\misc\juce_WebBrowserComponent.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\misc\juce_WebControlRelays.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_android_PushNotifications.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_ActiveXComponent_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_android_WebBrowserComponent.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_AndroidViewComponent.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_HWNDComponent_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_ios_PushNotifications.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_PushNotifications_android.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_linux_X11_SystemTrayIcon.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_PushNotifications_ios.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_linux_X11_WebBrowserComponent.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_PushNotifications_mac.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_linux_XEmbedComponent.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_SystemTrayIcon_linux.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_mac_PushNotifications.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_SystemTrayIcon_mac.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_mac_SystemTrayIcon.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_SystemTrayIcon_windows.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_win32_ActiveXComponent.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_WebBrowserComponent_android.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_win32_HWNDComponent.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_WebBrowserComponent_linux.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_win32_SystemTrayIcon.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_WebBrowserComponent_windows.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_XEmbedComponent_linux.cpp">
+    <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_win32_WebBrowserComponent.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\..\JUCE\modules\juce_gui_extra\juce_gui_extra.cpp">
@@ -2098,17 +1529,10 @@
     </ClCompile>
     <ClCompile Include="..\..\JuceLibraryCode\include_juce_audio_basics.cpp"/>
     <ClCompile Include="..\..\JuceLibraryCode\include_juce_audio_devices.cpp"/>
-    <ClCompile Include="..\..\JuceLibraryCode\include_juce_core.cpp">
-      <AdditionalOptions> /bigobj %(AdditionalOptions)</AdditionalOptions>
-    </ClCompile>
-    <ClCompile Include="..\..\JuceLibraryCode\include_juce_core_CompilationTime.cpp"/>
+    <ClCompile Include="..\..\JuceLibraryCode\include_juce_core.cpp"/>
     <ClCompile Include="..\..\JuceLibraryCode\include_juce_data_structures.cpp"/>
     <ClCompile Include="..\..\JuceLibraryCode\include_juce_events.cpp"/>
-    <ClCompile Include="..\..\JuceLibraryCode\include_juce_graphics.cpp">
-      <AdditionalOptions> /bigobj %(AdditionalOptions)</AdditionalOptions>
-    </ClCompile>
-    <ClCompile Include="..\..\JuceLibraryCode\include_juce_graphics_Harfbuzz.cpp"/>
-    <ClCompile Include="..\..\JuceLibraryCode\include_juce_graphics_Sheenbidi.c"/>
+    <ClCompile Include="..\..\JuceLibraryCode\include_juce_graphics.cpp"/>
     <ClCompile Include="..\..\JuceLibraryCode\include_juce_gui_basics.cpp">
       <AdditionalOptions> /bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
@@ -2126,10 +1550,8 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\midi\ump\juce_UMP.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\midi\ump\juce_UMPacket.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\midi\ump\juce_UMPackets.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\midi\ump\juce_UMPBytesOnGroup.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\midi\ump\juce_UMPConversion.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\midi\ump\juce_UMPConverters.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\midi\ump\juce_UMPDeviceInfo.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\midi\ump\juce_UMPDispatcher.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\midi\ump\juce_UMPFactory.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\midi\ump\juce_UMPIterator.h"/>
@@ -2156,9 +1578,8 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\mpe\juce_MPEUtils.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\mpe\juce_MPEValue.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\mpe\juce_MPEZoneLayout.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\native\juce_AudioWorkgroup_mac.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\native\juce_CoreAudioLayouts_mac.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\native\juce_CoreAudioTimeConversions_mac.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\native\juce_mac_CoreAudioLayouts.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\native\juce_mac_CoreAudioTimeConversions.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\sources\juce_AudioSource.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\sources\juce_BufferingAudioSource.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\sources\juce_ChannelRemappingAudioSource.h"/>
@@ -2171,7 +1592,6 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\sources\juce_ToneGeneratorAudioSource.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\synthesisers\juce_Synthesiser.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\utilities\juce_ADSR.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\utilities\juce_AudioWorkgroup.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\utilities\juce_Decibels.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\utilities\juce_GenericInterpolator.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_basics\utilities\juce_IIRFilter.h"/>
@@ -2192,12 +1612,8 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\include\oboe\AudioStreamBuilder.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\include\oboe\AudioStreamCallback.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\include\oboe\Definitions.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\include\oboe\FifoBuffer.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\include\oboe\FifoControllerBase.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\include\oboe\FullDuplexStream.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\include\oboe\LatencyTuner.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\include\oboe\Oboe.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\include\oboe\OboeExtensions.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\include\oboe\ResultWithValue.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\include\oboe\StabilizedCallback.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\include\oboe\Utilities.h"/>
@@ -2205,7 +1621,6 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\aaudio\AAudioExtensions.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\aaudio\AAudioLoader.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\aaudio\AudioStreamAAudio.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\common\AdpfWrapper.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\common\AudioClock.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\common\AudioSourceCaller.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\common\DataConversionFlowGraph.h"/>
@@ -2221,7 +1636,9 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\common\SourceI24Caller.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\common\SourceI32Caller.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\common\Trace.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\fifo\FifoBuffer.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\fifo\FifoController.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\fifo\FifoControllerBase.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\fifo\FifoControllerIndirect.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\HyperbolicCosineWindow.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\IntegerRatio.h"/>
@@ -2231,28 +1648,22 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\PolyphaseResampler.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\PolyphaseResamplerMono.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\PolyphaseResamplerStereo.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\ResamplerDefinitions.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\SincResampler.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\SincResamplerStereo.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\ChannelCountConverter.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\ClipToRange.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\FlowGraphNode.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\FlowgraphUtilities.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\Limiter.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\ManyToMultiConverter.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\MonoBlend.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\MonoToMultiConverter.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\MultiToManyConverter.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\MultiToMonoConverter.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\RampLinear.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\SampleRateConverter.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkFloat.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI8_24.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI16.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI24.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI32.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceFloat.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI8_24.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI16.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI24.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI32.h"/>
@@ -2263,8 +1674,8 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\opensles\EngineOpenSLES.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\opensles\OpenSLESUtilities.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\opensles\OutputMixerOpenSLES.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_Audio_ios.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_HighPerformanceAudioHelpers_android.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_android_HighPerformanceAudioHelpers.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\native\juce_ios_Audio.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\sources\juce_AudioSourcePlayer.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\sources\juce_AudioTransportSource.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_audio_devices\juce_audio_devices.h"/>
@@ -2274,8 +1685,6 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\containers\juce_ArrayBase.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\containers\juce_DynamicObject.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\containers\juce_ElementComparator.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\containers\juce_Enumerate.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\containers\juce_FixedSizeFunction.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\containers\juce_HashMap.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\containers\juce_LinkedListPointer.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\containers\juce_ListenerList.h"/>
@@ -2287,12 +1696,8 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\containers\juce_ScopedValueSetter.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\containers\juce_SingleThreadedAbstractFifo.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\containers\juce_SortedSet.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\containers\juce_Span.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\containers\juce_SparseSet.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\containers\juce_Variant.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\detail\juce_CallbackListenerList.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\detail\juce_LruCache.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\detail\juce_NativeFileHandle.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\files\juce_AndroidDocument.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\files\juce_common_MimeTypes.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\files\juce_DirectoryIterator.h"/>
@@ -2305,9 +1710,8 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\files\juce_RangedDirectoryIterator.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\files\juce_TemporaryFile.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\files\juce_WildcardFileFilter.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\json\juce_JSON.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\json\juce_JSONSerialisation.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\json\juce_JSONUtils.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_core\javascript\juce_Javascript.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_core\javascript\juce_JSON.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\logging\juce_FileLogger.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\logging\juce_Logger.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\maths\juce_BigInteger.h"/>
@@ -2321,7 +1725,6 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\memory\juce_Atomic.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\memory\juce_ByteOrder.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\memory\juce_ContainerDeletePolicy.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\memory\juce_CopyableHeapBlock.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\memory\juce_HeapBlock.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\memory\juce_HeavyweightLeakedObjectDetector.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\memory\juce_LeakedObjectDetector.h"/>
@@ -2335,31 +1738,26 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\memory\juce_Singleton.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\memory\juce_WeakReference.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\misc\juce_ConsoleApplication.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\misc\juce_EnumHelpers.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\misc\juce_Functional.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\misc\juce_OptionsHelpers.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\misc\juce_Result.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\misc\juce_RuntimePermissions.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\misc\juce_ScopeGuard.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\misc\juce_Uuid.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\misc\juce_WindowsRegistry.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_core\native\juce_android_JNIHelpers.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\native\juce_BasicNativeHeaders.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\native\juce_CFHelpers_mac.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\native\juce_ComSmartPtr_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\native\juce_IPAddress_posix.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\native\juce_JNIHelpers_android.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\native\juce_ObjCHelpers_mac.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\native\juce_PlatformTimerListener.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\native\juce_SharedCode_intel.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\native\juce_SharedCode_posix.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\native\juce_ThreadPriorities_native.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_core\native\juce_intel_SharedCode.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_core\native\juce_mac_CFHelpers.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_core\native\juce_mac_ObjCHelpers.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_core\native\juce_native_ThreadPriorities.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_core\native\juce_posix_IPAddress.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_core\native\juce_posix_SharedCode.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_core\native\juce_win32_ComSmartPtr.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\network\juce_IPAddress.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\network\juce_MACAddress.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\network\juce_NamedPipe.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\network\juce_Socket.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\network\juce_URL.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\network\juce_WebInputStream.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\serialisation\juce_Serialisation.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\streams\juce_AndroidDocumentInputSource.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\streams\juce_BufferedInputStream.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\streams\juce_FileInputSource.h"/>
@@ -2414,21 +1812,9 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\unit_tests\juce_UnitTestCategories.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\xml\juce_XmlDocument.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\xml\juce_XmlElement.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\zip\zlib\crc32.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\zip\zlib\deflate.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\zip\zlib\gzguts.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\zip\zlib\inffast.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\zip\zlib\inffixed.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\zip\zlib\inflate.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\zip\zlib\inftrees.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\zip\zlib\trees.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\zip\zlib\zconf.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\zip\zlib\zlib.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\zip\zlib\zutil.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\zip\juce_GZIPCompressorOutputStream.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\zip\juce_GZIPDecompressorInputStream.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\zip\juce_ZipFile.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_core\zip\juce_zlib.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_core\juce_core.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_data_structures\app_properties\juce_ApplicationProperties.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_data_structures\app_properties\juce_PropertiesFile.h"/>
@@ -2445,8 +1831,6 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_events\broadcasters\juce_AsyncUpdater.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_events\broadcasters\juce_ChangeBroadcaster.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_events\broadcasters\juce_ChangeListener.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_events\broadcasters\juce_LockingAsyncUpdater.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_events\interprocess\juce_ChildProcessManager.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_events\interprocess\juce_ConnectedChildProcess.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_events\interprocess\juce_InterprocessConnection.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_events\interprocess\juce_InterprocessConnectionServer.h"/>
@@ -2460,15 +1844,13 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_events\messages\juce_MessageManager.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_events\messages\juce_MountedVolumeListChangeDetector.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_events\messages\juce_NotificationType.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_events\native\juce_EventLoop_linux.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_events\native\juce_EventLoopInternal_linux.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_events\native\juce_HiddenMessageWindow_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_events\native\juce_MessageQueue_mac.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_events\native\juce_RunningInUnity.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_events\native\juce_linux_EventLoop.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_events\native\juce_linux_EventLoopInternal.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_events\native\juce_osx_MessageQueue.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_events\native\juce_ScopedLowPowerModeDisabler.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_events\native\juce_WinRTWrapper_windows.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_events\native\juce_win32_HiddenMessageWindow.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_events\native\juce_win32_WinRTWrapper.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_events\timers\juce_MultiTimer.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_events\timers\juce_TimedCallback.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_events\timers\juce_Timer.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_events\juce_events.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\colour\juce_Colour.h"/>
@@ -2478,300 +1860,17 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\colour\juce_PixelFormats.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\contexts\juce_GraphicsContext.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\contexts\juce_LowLevelGraphicsContext.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\contexts\juce_LowLevelGraphicsPostScriptRenderer.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\contexts\juce_LowLevelGraphicsSoftwareRenderer.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\detail\juce_JustifiedText.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\detail\juce_Ranges.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\detail\juce_ShapedText.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\detail\juce_SimpleShapedText.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\detail\juce_Unicode.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\effects\juce_DropShadowEffect.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\effects\juce_GlowEffect.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\effects\juce_ImageEffectFilter.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Color\CBDT\CBDT.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Color\COLR\COLR.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Color\COLR\colrv1-closure.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Color\CPAL\CPAL.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Color\sbix\sbix.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Color\svg\svg.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\glyf\composite-iter.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\glyf\CompositeGlyph.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\glyf\glyf-helpers.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\glyf\glyf.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\glyf\Glyph.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\glyf\GlyphHeader.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\glyf\loca.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\glyf\path-builder.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\glyf\SimpleGlyph.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\glyf\SubsetGlyph.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\Common\Coverage.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\Common\CoverageFormat1.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\Common\CoverageFormat2.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\Common\RangeRecord.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GDEF\GDEF.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\Anchor.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\AnchorFormat1.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\AnchorFormat2.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\AnchorFormat3.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\AnchorMatrix.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\ChainContextPos.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\Common.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\ContextPos.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\CursivePos.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\CursivePosFormat1.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\ExtensionPos.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\GPOS.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\LigatureArray.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\MarkArray.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\MarkBasePos.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\MarkBasePosFormat1.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\MarkLigPos.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\MarkLigPosFormat1.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\MarkMarkPos.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\MarkMarkPosFormat1.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\MarkRecord.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\PairPos.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\PairPosFormat1.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\PairPosFormat2.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\PairSet.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\PairValueRecord.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\PosLookup.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\PosLookupSubTable.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\SinglePos.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\SinglePosFormat1.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\SinglePosFormat2.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GPOS\ValueFormat.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\AlternateSet.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\AlternateSubst.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\AlternateSubstFormat1.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\ChainContextSubst.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\Common.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\ContextSubst.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\ExtensionSubst.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\GSUB.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\Ligature.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\LigatureSet.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\LigatureSubst.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\LigatureSubstFormat1.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\MultipleSubst.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\MultipleSubstFormat1.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\ReverseChainSingleSubst.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\ReverseChainSingleSubstFormat1.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\Sequence.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\SingleSubst.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\SingleSubstFormat1.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\SingleSubstFormat2.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\SubstLookup.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\GSUB\SubstLookupSubTable.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Layout\types.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\name\name.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Var\VARC\coord-setter.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\OT\Var\VARC\VARC.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-aat-layout-ankr-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-aat-layout-bsln-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-aat-layout-common.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-aat-layout-feat-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-aat-layout-just-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-aat-layout-kerx-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-aat-layout-morx-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-aat-layout-opbd-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-aat-layout-trak-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-aat-layout.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-aat-layout.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-aat-ltag-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-aat-map.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-aat.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-algs.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-array.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-atomic.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-bimap.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-bit-page.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-bit-set-invertible.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-bit-set.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-blob.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-blob.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-buffer-deserialize-json.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-buffer-deserialize-text-glyphs.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-buffer-deserialize-text-unicode.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-buffer.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-buffer.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-cache.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-cff-interp-common.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-cff-interp-cs-common.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-cff-interp-dict-common.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-cff1-interp-cs.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-cff2-interp-cs.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-common.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-config.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-coretext.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-cplusplus.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-debug.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-deprecated.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-directwrite.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-dispatch.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-draw.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-draw.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-face.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-face.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-font.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-font.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ft-colr.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ft.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-gdi.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-geometry.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-glib.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-gobject-structs.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-gobject.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-graphite2.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-icu.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-iter.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-kern.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-limits.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-machinery.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-map.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-map.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-meta.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ms-feature-ranges.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-multimap.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-mutex.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-null.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-number-parser.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-number.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-object.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-open-file.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-open-type.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-cff-common.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-cff1-std-str.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-cff1-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-cff2-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-cmap-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-color.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-deprecated.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-face-table-list.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-face.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-font.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-gasp-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-glyf-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-hdmx-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-head-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-hhea-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-hmtx-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-kern-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-layout-base-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-layout-common.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-layout-gdef-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-layout-gpos-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-layout-gsub-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-layout-gsubgpos.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-layout-jstf-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-layout.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-layout.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-map.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-math-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-math.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-maxp-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-meta-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-meta.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-metrics.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-metrics.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-name-language-static.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-name-language.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-name-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-name.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-os2-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-os2-unicode-ranges.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-post-macroman.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-post-table-v2subset.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-post-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shape-fallback.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shape-normalize.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shape.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shape.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-arabic-fallback.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-arabic-joining-list.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-arabic-pua.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-arabic-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-arabic-win1256.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-arabic.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-indic-machine.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-indic.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-khmer-machine.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-myanmar-machine.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-syllabic.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-use-machine.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-use-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper-vowel-constraints.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-shaper.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-stat-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-tag-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-var-avar-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-var-common.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-var-cvar-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-var-fvar-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-var-gvar-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-var-hvar-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-var-mvar-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-var-varc-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-var.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot-vorg-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ot.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-outline.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-paint-extents.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-paint.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-paint.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-pool.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-priority-queue.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-repacker.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-sanitize.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-serialize.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-set-digest.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-set.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-set.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-shape-plan.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-shape-plan.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-shape.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-shaper-impl.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-shaper-list.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-shaper.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-string-array.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-style.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-subset-accelerator.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-subset-cff-common.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-subset-input.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-subset-instancer-iup.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-subset-instancer-solver.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-subset-plan-member-list.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-subset-plan.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-subset-repacker.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-subset.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-subset.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-ucd-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-unicode-emoji-table.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-unicode.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-unicode.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-uniscribe.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-utf.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-vector.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-version.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-wasm-api-blob.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-wasm-api-buffer.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-wasm-api-common.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-wasm-api-face.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-wasm-api-font.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-wasm-api-list.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-wasm-api-shape.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-wasm-api.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb-wasm-api.hh"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\harfbuzz\hb.hh"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\juce_AttributedString.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\juce_CustomTypeface.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\juce_Font.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\juce_FontOptions.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\juce_FunctionPointerDestructor.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\juce_GlyphArrangement.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\juce_GlyphArrangementOptions.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\juce_TextLayout.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\juce_Typeface.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\fonts\juce_TypefaceFileCache.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\geometry\juce_AffineTransform.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\geometry\juce_BorderSize.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\geometry\juce_EdgeTable.h"/>
@@ -2783,81 +1882,17 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\geometry\juce_Point.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\geometry\juce_Rectangle.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\geometry\juce_RectangleList.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\cderror.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jchuff.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jconfig.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jdct.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jdhuff.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jerror.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jinclude.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jmemsys.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jmorecfg.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jpegint.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jpeglib.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\jversion.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\transupp.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\png.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\pngconf.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\pngdebug.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\pnginfo.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\pngpriv.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\pngstruct.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\images\juce_Image.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\images\juce_ImageCache.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\images\juce_ImageConvolutionKernel.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\images\juce_ImageFileFormat.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\images\juce_ImagePixelDataNativeExtensions.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\images\juce_ScaledImage.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\native\juce_CoreGraphicsContext_mac.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\native\juce_CoreGraphicsHelpers_mac.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\native\juce_Direct2DGraphicsContext_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\native\juce_Direct2DGraphicsContextImpl_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\native\juce_Direct2DImage_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\native\juce_Direct2DImageContext_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\native\juce_Direct2DMetrics_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\native\juce_Direct2DPixelDataPage_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\native\juce_DirectX_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\native\juce_EventTracing.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\native\juce_mac_CoreGraphicsContext.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\native\juce_mac_CoreGraphicsHelpers.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\native\juce_RenderingHelpers.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\native\juce_win32_Direct2DGraphicsContext.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\placement\juce_Justification.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\placement\juce_RectanglePlacement.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Headers\SBAlgorithm.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Headers\SBBase.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Headers\SBBidiType.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Headers\SBCodepoint.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Headers\SBCodepointSequence.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Headers\SBConfig.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Headers\SBGeneralCategory.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Headers\SBLine.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Headers\SBMirrorLocator.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Headers\SBParagraph.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Headers\SBRun.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Headers\SBScript.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Headers\SBScriptLocator.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Headers\SheenBidi.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\BidiChain.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\BidiTypeLookup.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\BracketQueue.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\BracketType.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\GeneralCategoryLookup.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\IsolatingRun.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\LevelRun.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\PairingLookup.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\RunExtrema.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\RunKind.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\RunQueue.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\SBAlgorithm.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\SBAssert.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\SBBase.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\SBCodepointSequence.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\SBLine.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\SBLog.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\SBMirrorLocator.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\SBParagraph.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\SBScriptLocator.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\ScriptLookup.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\ScriptStack.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\Source\StatusStack.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_graphics\juce_graphics.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\accessibility\enums\juce_AccessibilityActions.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\accessibility\enums\juce_AccessibilityEvent.h"/>
@@ -2891,28 +1926,6 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\components\juce_ModalComponentManager.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\desktop\juce_Desktop.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\desktop\juce_Displays.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_AccessibilityHelpers.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_AlertWindowHelpers.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_ButtonAccessibilityHandler.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_ComponentHelpers.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_ComponentPeerHelpers.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_CustomMouseCursorInfo.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_FocusHelpers.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_FocusRestorer.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_LookAndFeelHelpers.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_MouseInputSourceImpl.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_MouseInputSourceList.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_PointerState.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_ScalingHelpers.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_ScopedContentSharerImpl.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_ScopedContentSharerInterface.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_ScopedMessageBoxImpl.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_ScopedMessageBoxInterface.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_StandardCachedComponentImage.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_ToolbarItemDragAndDropOverlayComponent.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_TopLevelWindowManager.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_ViewportHelpers.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\detail\juce_WindowingHelpers.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\drawables\juce_Drawable.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\drawables\juce_DrawableComposite.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\drawables\juce_DrawableImage.h"/>
@@ -2943,7 +1956,6 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\keyboard\juce_TextInputTarget.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\layout\juce_AnimatedPosition.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\layout\juce_AnimatedPositionBehaviours.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\layout\juce_BorderedComponentBoundsConstrainer.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\layout\juce_ComponentAnimator.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\layout\juce_ComponentBoundsConstrainer.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\layout\juce_ComponentBuilder.h"/>
@@ -2978,6 +1990,7 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\misc\juce_BubbleComponent.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\misc\juce_DropShadower.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\misc\juce_FocusOutline.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\misc\juce_JUCESplashScreen.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\mouse\juce_ComponentDragger.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\mouse\juce_DragAndDropContainer.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\mouse\juce_DragAndDropTarget.h"/>
@@ -2988,37 +2001,36 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\mouse\juce_MouseInactivityDetector.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\mouse\juce_MouseInputSource.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\mouse\juce_MouseListener.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\mouse\juce_PointerState.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\mouse\juce_SelectedItemSet.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\mouse\juce_TextDragAndDropTarget.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\mouse\juce_TooltipClient.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_AccessibilityElement_windows.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_AccessibilityTextHelpers.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_UIAExpandCollapseProvider_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_UIAGridItemProvider_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_UIAGridProvider_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_UIAHelpers_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_UIAInvokeProvider_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_UIAProviderBase_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_UIAProviders_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_UIARangeValueProvider_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_UIASelectionProvider_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_UIATextProvider_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_UIAToggleProvider_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_UIATransformProvider_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_UIAValueProvider_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_UIAWindowProvider_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_WindowsUIAWrapper_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_CGMetalLayerRenderer_mac.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_Direct2DHwndContext_windows.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_win32_AccessibilityElement.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_win32_ComInterfaces.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_win32_UIAExpandCollapseProvider.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_win32_UIAGridItemProvider.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_win32_UIAGridProvider.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_win32_UIAHelpers.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_win32_UIAInvokeProvider.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_win32_UIAProviderBase.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_win32_UIAProviders.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_win32_UIARangeValueProvider.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_win32_UIASelectionProvider.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_win32_UIATextProvider.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_win32_UIAToggleProvider.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_win32_UIATransformProvider.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_win32_UIAValueProvider.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_win32_UIAWindowProvider.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_win32_WindowsUIAWrapper.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\x11\juce_linux_ScopedWindowAssociation.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\x11\juce_linux_X11_Symbols.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\x11\juce_linux_XWindowSystem.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_mac_CGMetalLayerRenderer.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_mac_PerScreenDisplayLinks.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_MultiTouchMapper.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_NativeModalWrapperComponent_ios.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_PerScreenDisplayLinks_mac.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_ScopedDPIAwarenessDisabler.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_ScopedThreadDPIAwarenessSetter_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_ScopedWindowAssociation_linux.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_WindowsHooks_windows.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_XSymbols_linux.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_XWindowSystem_linux.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\native\juce_win32_ScopedThreadDPIAwarenessSetter.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\positioning\juce_MarkerList.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\positioning\juce_RelativeCoordinate.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\positioning\juce_RelativeCoordinatePositioner.h"/>
@@ -3055,14 +2067,11 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_DocumentWindow.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_MessageBoxOptions.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_NativeMessageBox.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_NativeScaleFactorNotifier.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_ResizableWindow.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_ScopedMessageBox.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_ThreadWithProgressWindow.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_TooltipWindow.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_TopLevelWindow.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_VBlankAttachment.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_WindowUtils.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\windows\juce_VBlankAttachement.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_basics\juce_gui_basics.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_extra\code_editor\juce_CodeDocument.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_extra\code_editor\juce_CodeEditorComponent.h"/>
@@ -3071,7 +2080,6 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_extra\code_editor\juce_CPlusPlusCodeTokeniserFunctions.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_extra\code_editor\juce_LuaCodeTokeniser.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_extra\code_editor\juce_XMLCodeTokeniser.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_extra\detail\juce_WebControlRelayEvents.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_extra\documents\juce_FileBasedDocument.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_extra\embedding\juce_ActiveXControlComponent.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_extra\embedding\juce_AndroidViewComponent.h"/>
@@ -3091,26 +2099,19 @@
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_extra\misc\juce_SplashScreen.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_extra\misc\juce_SystemTrayIconComponent.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_extra\misc\juce_WebBrowserComponent.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_extra\misc\juce_WebControlParameterIndexReceiver.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_extra\misc\juce_WebControlRelays.h"/>
-    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_NSViewFrameWatcher_mac.h"/>
+    <ClInclude Include="..\..\..\JUCE\modules\juce_gui_extra\native\juce_mac_NSViewFrameWatcher.h"/>
     <ClInclude Include="..\..\..\JUCE\modules\juce_gui_extra\juce_gui_extra.h"/>
     <ClInclude Include="..\..\JuceLibraryCode\AppConfig.h"/>
     <ClInclude Include="..\..\JuceLibraryCode\JuceHeader.h"/>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\common\README.md"/>
-    <None Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\README.md"/>
     <None Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\CMakeLists.txt"/>
     <None Include="..\..\..\JUCE\modules\juce_audio_devices\native\oboe\README.md"/>
     <None Include="..\..\..\JUCE\modules\juce_core\native\java\README.txt"/>
-    <None Include="..\..\..\JUCE\modules\juce_core\zip\zlib\JUCE_CHANGES.txt"/>
-    <None Include="..\..\..\JUCE\modules\juce_graphics\image_formats\jpglib\changes to libjpeg for JUCE.txt"/>
-    <None Include="..\..\..\JUCE\modules\juce_graphics\image_formats\pnglib\libpng_readme.txt"/>
-    <None Include="..\..\..\JUCE\modules\juce_graphics\unicode\sheenbidi\JUCE_CHANGES.txt"/>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include=".\resources.rc"/>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
+  <ImportGroup Label="ExtensionTargets"/>
 </Project>

--- a/OrkideMIDI/OrkideMIDI.jucer
+++ b/OrkideMIDI/OrkideMIDI.jucer
@@ -19,6 +19,10 @@
   <EXPORTFORMATS>
     <VS2022 targetFolder="Builds/VisualStudio2022" platformName="x64" os="windows"
             useStandardRuntimePaths="1" cppLanguageStandard="17">
+      <CONFIGURATIONS>
+        <CONFIGURATION name="Debug" isDebug="1"/>
+        <CONFIGURATION name="Release" isDebug="0"/>
+      </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_audio_devices" path="../JUCE/modules"/>
         <MODULEPATH id="juce_audio_basics" path="../JUCE/modules"/>


### PR DESCRIPTION
## Summary
- revert previous submodule commit
- add `<CONFIGURATIONS>` block to `OrkideMIDI.jucer`
- regenerate Visual Studio solution and project files

## Testing
- `Projucer --resave OrkideMIDI/OrkideMIDI.jucer`
- `python3 -m py_compile calculator.py`


------
https://chatgpt.com/codex/tasks/task_e_685153cb0f4c832dbdfc16a31201560d